### PR TITLE
Add simple read interface

### DIFF
--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -271,6 +271,21 @@ contract DapiServer is WhitelistWithManager, Median, IDapiServer {
         return (dataPoint.value, dataPoint.timestamp);
     }
 
+    function readDataPointValueWithId(bytes32 dataPointId)
+        external
+        view
+        override
+        returns (int224 value)
+    {
+        require(
+            readerCanReadDataPoint(dataPointId, msg.sender),
+            "Sender cannot read"
+        );
+        DataPoint storage dataPoint = dataPoints[dataPointId];
+        require(dataPoint.timestamp != 0, "Data point does not exist");
+        return dataPoints[dataPointId].value;
+    }
+
     /// @notice Reads the data point with name
     /// @dev The read data point may belong to a Beacon or dAPI. The reader
     /// must be whitelisted for the hash of the data point name.

--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -309,6 +309,24 @@ contract DapiServer is WhitelistWithManager, Median, IDapiServer {
         return (dataPoint.value, dataPoint.timestamp);
     }
 
+    function readDataPointValueWithName(bytes32 name)
+        external
+        view
+        override
+        returns (int224 value)
+    {
+        bytes32 nameHash = keccak256(abi.encodePacked(name));
+        require(
+            readerCanReadDataPoint(nameHash, msg.sender),
+            "Sender cannot read"
+        );
+        DataPoint storage dataPoint = dataPoints[
+            nameHashToDataPointId[nameHash]
+        ];
+        require(dataPoint.timestamp != 0, "Data feed does not exist");
+        return dataPoint.value;
+    }
+
     /// @notice Returns if a reader can read the data point
     /// @param dataPointId Data point ID (or data point name hash)
     /// @param reader Reader address

--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -257,7 +257,7 @@ contract DapiServer is WhitelistWithManager, Median, IDapiServer {
     /// @param dataPointId Data point ID
     /// @return value Data point value
     /// @return timestamp Data point timestamp
-    function readWithDataPointId(bytes32 dataPointId)
+    function readDataPointWithId(bytes32 dataPointId)
         external
         view
         override
@@ -277,7 +277,7 @@ contract DapiServer is WhitelistWithManager, Median, IDapiServer {
     /// @param name Data point name
     /// @return value Data point value
     /// @return timestamp Data point timestamp
-    function readWithName(bytes32 name)
+    function readDataPointWithName(bytes32 name)
         external
         view
         override

--- a/contracts/dapis/interfaces/IDapiReader.sol
+++ b/contracts/dapis/interfaces/IDapiReader.sol
@@ -22,4 +22,9 @@ interface IBaseDapiServer {
         external
         view
         returns (int224 value, uint32 timestamp);
+
+    function readDataPointValueWithName(bytes32 name)
+        external
+        view
+        returns (int224 value);
 }

--- a/contracts/dapis/interfaces/IDapiReader.sol
+++ b/contracts/dapis/interfaces/IDapiReader.sol
@@ -8,12 +8,12 @@ interface IDapiReader {
 /// @dev We use the part of the interface that will persist between
 /// DapiServer versions
 interface IBaseDapiServer {
-    function readWithDataPointId(bytes32 dataPointId)
+    function readDataPointWithId(bytes32 dataPointId)
         external
         view
         returns (int224 value, uint32 timestamp);
 
-    function readWithName(bytes32 name)
+    function readDataPointWithName(bytes32 name)
         external
         view
         returns (int224 value, uint32 timestamp);

--- a/contracts/dapis/interfaces/IDapiReader.sol
+++ b/contracts/dapis/interfaces/IDapiReader.sol
@@ -13,6 +13,11 @@ interface IBaseDapiServer {
         view
         returns (int224 value, uint32 timestamp);
 
+    function readDataPointValueWithId(bytes32 dataPointId)
+        external
+        view
+        returns (int224 value);
+
     function readDataPointWithName(bytes32 name)
         external
         view

--- a/contracts/dapis/interfaces/IDapiServer.sol
+++ b/contracts/dapis/interfaces/IDapiServer.sol
@@ -65,6 +65,11 @@ interface IDapiServer {
         view
         returns (int224 value, uint32 timestamp);
 
+    function readDataPointValueWithName(bytes32 name)
+        external
+        view
+        returns (int224 value);
+
     function readerCanReadDataPoint(bytes32 dataPointId, address reader)
         external
         view

--- a/contracts/dapis/interfaces/IDapiServer.sol
+++ b/contracts/dapis/interfaces/IDapiServer.sol
@@ -50,12 +50,12 @@ interface IDapiServer {
 
     function nameToDataPointId(bytes32 name) external view returns (bytes32);
 
-    function readWithDataPointId(bytes32 dataPointId)
+    function readDataPointWithId(bytes32 dataPointId)
         external
         view
         returns (int224 value, uint32 timestamp);
 
-    function readWithName(bytes32 name)
+    function readDataPointWithName(bytes32 name)
         external
         view
         returns (int224 value, uint32 timestamp);

--- a/contracts/dapis/interfaces/IDapiServer.sol
+++ b/contracts/dapis/interfaces/IDapiServer.sol
@@ -55,6 +55,11 @@ interface IDapiServer {
         view
         returns (int224 value, uint32 timestamp);
 
+    function readDataPointValueWithId(bytes32 dataPointId)
+        external
+        view
+        returns (int224 value);
+
     function readDataPointWithName(bytes32 name)
         external
         view


### PR DESCRIPTION
Previously, the only interface for data points returned the value and timestamp packed into 32 bytes. Unpacking this may be too difficult for some reasons and the interface may not be natively compatible with oracle interfaces that exist a regular signed integer. As a solution additional functions are implemented that simply return a single signed integer.